### PR TITLE
Add autoheader to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If ZLib is already installed, building can be performed similar to the following
     cd fqtools/
     git clone https://github.com/samtools/htslib
     cd htslib/
+    autoheader
     autoconf 
     ./configure
     make


### PR DESCRIPTION
autoheader is needed for ./configure to succeed
See the official instructions: https://github.com/samtools/htslib